### PR TITLE
Simplify the renderRoutes method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog references the relevant changes done between versions.
 To get the diff for a specific change, go to https://github.com/FriendsOfECMAScript/ReactI18nRouting/commit/XXX where XXX is the change hash 
 To get the diff between two versions, go to https://github.com/FriendsOfECMAScript/ReactI18nRouting/compare/v0.4.0...v0.5.0
 
+* 0.6.0 (Planned release)
+    * Made `renderRoutes` method more simple to use.
 * 0.5.1
     * Fixed PropType reference in the basic usage chapter from documentation.
     * Fixed wrong PropType in the BrowserIntlProvider.

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -36,7 +36,7 @@ application bootstrapping.
 ```javascript
 // src/i18n/index.js
 
-import {defaultUnprefixed, getLocale} from '@foes/react-i18n-routing';
+import {defaultUnprefixed} from '@foes/react-i18n-routing';
 import {addLocaleData} from 'react-intl';
 import en from 'react-intl/locale-data/en';
 import es from 'react-intl/locale-data/es';
@@ -61,7 +61,7 @@ export default {
   formatIntlRoute: languageStrategy.formatIntlRoute,
   localeFromLocation: languageStrategy.localeFromLocation,
   messages: {en: messagesEn, es: messagesEs, eu: messagesEu, fr: messagesFr},
-  renderRoutes: config => languageStrategy.renderRoutes(getLocale())(config),
+  renderRoutes: languageStrategy.renderRoutes,
 };
 ```
 It has been built on top of **react-router-config**, and each language strategy provides a helper to transform

--- a/src/languageStrategy/defaultUnprefixed.js
+++ b/src/languageStrategy/defaultUnprefixed.js
@@ -60,5 +60,5 @@ export default ({routes, locales, defaultLocale}) => ({
     locales,
     routes,
     pathFromRouteForPathsAndLocale(defaultLocale, pathFromRoute),
-  ),
+  )(getLocale())(routes),
 });

--- a/src/languageStrategy/subdomainBased.js
+++ b/src/languageStrategy/subdomainBased.js
@@ -64,5 +64,5 @@ export default ({routes, locales, defaultLocale, subdomains, domain}) => ({
     locales,
     routes,
     pathFromRouteForPathsAndLocale(defaultLocale, pathFromRoute),
-  ),
+  )(getLocale())(routes),
 });


### PR DESCRIPTION
Because after v0.3.0 we have current locale decoupled from the `BrowseIntlProvider` itself, in order to improve the DX we can simplify the boilerplate around `renderRoutes` method hidding the execution of the functions.

Before:
```javascript
// src/i18n/index.js

export default {
  formatIntlRoute: languageStrategy.formatIntlRoute,
  localeFromLocation: languageStrategy.localeFromLocation,
  messages: {en: messagesEn, es: messagesEs, eu: messagesEu, fr: messagesFr},
  renderRoutes: languageStrategy.renderRoutes(getLocale())(config),
};
```

After: 
```javascript
// src/i18n/index.js

export default {
  formatIntlRoute: languageStrategy.formatIntlRoute,
  localeFromLocation: languageStrategy.localeFromLocation,
  messages: {en: messagesEn, es: messagesEs, eu: messagesEu, fr: messagesFr},
  renderRoutes: languageStrategy.renderRoutes,
};
```