### PR TITLE
Fix unprefixed strategy when URL starts with another locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "README.md"
   ],
   "jest": {
-    "testRegex": "(/tests/.*|(\\.|/)(test|spec))\\.jsx?$"
+    "testRegex": "(/tests/.*|(\\.|/)(test|spec))\\.jsx?$",
+    "testURL": "http://localhost"
   },
   "babel": {
     "presets": [

--- a/src/languageStrategy/defaultUnprefixed.js
+++ b/src/languageStrategy/defaultUnprefixed.js
@@ -14,7 +14,7 @@ import renderTranslatedRoutes from './../renderTranslatedRoutes.js';
 import pathFromRouteForPathsAndLocale from './pathFromRouteForPathsAndLocale.js';
 
 const localeFromLocation = (locales, defaultLocale) => location => {
-  const match = /^\/([a-z]{2}).*/g.exec(location.pathname);
+  const match = /^\/([a-z]{2})(\/|$).*/g.exec(location.pathname);
   if (match && locales.indexOf(match[1]) > -1) {
     return match[1];
   }

--- a/tests/languageStrategy/defaultUnprefixed.js
+++ b/tests/languageStrategy/defaultUnprefixed.js
@@ -28,6 +28,9 @@ test('It detects locale based in location', () => {
   expect(
     languageStrategy.localeFromLocation({pathname: '/eu/some-route'}),
   ).toBe('eu');
+  expect(languageStrategy.localeFromLocation({pathname: '/estrategy'})).toBe(
+    'en',
+  );
 });
 
 test('Generates valid react-router-config tree', () => {

--- a/tests/languageStrategy/defaultUnprefixed.js
+++ b/tests/languageStrategy/defaultUnprefixed.js
@@ -29,7 +29,7 @@ test('It detects locale based in location', () => {
     languageStrategy.localeFromLocation({pathname: '/eu/some-route'}),
   ).toBe('eu');
   expect(
-    languageStrategy.localeFromLocation({pathname: '/estrategy'}),
+    languageStrategy.localeFromLocation({pathname: '/estrategy-url'}),
   ).toBe('en');
 });
 

--- a/tests/languageStrategy/defaultUnprefixed.js
+++ b/tests/languageStrategy/defaultUnprefixed.js
@@ -28,9 +28,9 @@ test('It detects locale based in location', () => {
   expect(
     languageStrategy.localeFromLocation({pathname: '/eu/some-route'}),
   ).toBe('eu');
-  expect(languageStrategy.localeFromLocation({pathname: '/estrategy'})).toBe(
-    'en',
-  );
+  expect(
+    languageStrategy.localeFromLocation({pathname: '/estrategy'}),
+  ).toBe('en');
 });
 
 test('Generates valid react-router-config tree', () => {


### PR DESCRIPTION
There is an error when trying to access URLs like `/estrategy` with `en` as default locale. It matches `es` in that URL and determines that that should be the locale