### PR TITLE
LocaleContext out-of-the-box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # For the full copyright and license information, please view the LICENSE
 # file that was distributed with this source code.
 
+coverage
 dist
 node_modules
 package-lock.json

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -85,11 +85,6 @@ const languageStrategy = defaultUnprefixed({
   locales: ['eu', 'es', 'en', 'fr'],
   defaultLocale: 'es'
 });
-<<<<<<< HEAD
-const LocaleContext = withI18nRouting(({i18nRouting, children}) => children(i18nRouting.locale));
-=======
-const renderRoutes = (locale, config) => languageStrategy.renderRoutes(locale)(config);
->>>>>>> Moved withI18nRouting to private api and provided LocaleContext component out-of-the-box
 
 const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate;
 

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -73,7 +73,7 @@ The following file is the entry point of your React app.
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {I18nRoutingProvider} from '@foes/react-i18n-routing';
+import {I18nRoutingProvider, LocaleContext} from '@foes/react-i18n-routing';
 import createHistory from 'history/createBrowserHistory';
 
 import routes from './routing/config';
@@ -85,7 +85,11 @@ const languageStrategy = defaultUnprefixed({
   locales: ['eu', 'es', 'en', 'fr'],
   defaultLocale: 'es'
 });
+<<<<<<< HEAD
 const LocaleContext = withI18nRouting(({i18nRouting, children}) => children(i18nRouting.locale));
+=======
+const renderRoutes = (locale, config) => languageStrategy.renderRoutes(locale)(config);
+>>>>>>> Moved withI18nRouting to private api and provided LocaleContext component out-of-the-box
 
 const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate;
 

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -96,7 +96,7 @@ renderMethod(
     localeFromPath={languageStrategy.localeFromLocation}
   >
     <LocaleContext>
-      {locale => languageStrategy.renderRoutes(locale)(routes)}
+      {({locale}) => languageStrategy.renderRoutes(locale)(routes)}
     </LocaleContext>
   </I18nRoutingProvider>,
   document.getElementById('root')

--- a/src/component/LocaleContext.js
+++ b/src/component/LocaleContext.js
@@ -1,3 +1,12 @@
+/*
+ * This file is part of the ReactI18nRouting package.
+ *
+ * Copyright (c) 2018-present Friends Of ECMAScript
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 import withI18nRouting from './withI18nRouting';
 
 export default withI18nRouting(({i18nRouting, children}) => children(i18nRouting.locale));

--- a/src/component/LocaleContext.js
+++ b/src/component/LocaleContext.js
@@ -9,4 +9,4 @@
 
 import withI18nRouting from './withI18nRouting';
 
-export default withI18nRouting(({i18nRouting, children}) => children(i18nRouting.locale));
+export default withI18nRouting(({i18nRouting, children}) => children(i18nRouting));

--- a/src/component/LocaleContext.js
+++ b/src/component/LocaleContext.js
@@ -1,0 +1,3 @@
+import withI18nRouting from './withI18nRouting';
+
+export default withI18nRouting(({i18nRouting, children}) => children(i18nRouting.locale));

--- a/src/component/withI18nRouting.js
+++ b/src/component/withI18nRouting.js
@@ -11,8 +11,6 @@ import React from 'react';
 
 import I18nRoutingContext from './I18nRoutingContext';
 
-export const withI18nRouting = Component => props => (
+export default Component => props => (
   <I18nRoutingContext.Consumer>{context => <Component i18nRouting={context} {...props} />}</I18nRoutingContext.Consumer>
 );
-
-export default withI18nRouting;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@
 
 import {FormattedLink, FormattedNavLink, FormattedRedirect} from './component/FormattedReactRouter.js';
 import I18nRoutingProvider from './component/I18nRoutingProvider';
-import withI18nRouting from './component/withI18nRouting';
+import LocaleContext from './component/LocaleContext';
 import defaultUnPrefixed from './languageStrategy/defaultUnprefixed.js';
 import subdomainBased from './languageStrategy/subdomainBased.js';
 import renderTranslatedRoutes from './renderTranslatedRoutes.js';
@@ -19,7 +19,7 @@ export {
   FormattedNavLink,
   FormattedRedirect,
   I18nRoutingProvider,
-  withI18nRouting,
+  LocaleContext,
   defaultUnPrefixed,
   subdomainBased,
   renderTranslatedRoutes,

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@
 
 import {FormattedLink, FormattedNavLink, FormattedRedirect} from './component/FormattedReactRouter.js';
 import I18nRoutingProvider from './component/I18nRoutingProvider';
+import withI18nRouting from './component/withI18nRouting';
 import LocaleContext from './component/LocaleContext';
 import defaultUnPrefixed from './languageStrategy/defaultUnprefixed.js';
 import subdomainBased from './languageStrategy/subdomainBased.js';
@@ -19,6 +20,7 @@ export {
   FormattedNavLink,
   FormattedRedirect,
   I18nRoutingProvider,
+  withI18nRouting,
   LocaleContext,
   defaultUnPrefixed,
   subdomainBased,

--- a/tests/component/LocaleContext.js
+++ b/tests/component/LocaleContext.js
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the ReactI18nRouting package.
+ *
+ * Copyright (c) 2018-present Friends Of ECMAScript
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import React from 'react';
+import {render} from 'react-testing-library';
+import createHistory from 'history/createMemoryHistory';
+
+import I18nRoutingProvider from './../../src/component/I18nRoutingProvider';
+import defaultUnprefixed from './../../src/languageStrategy/defaultUnprefixed';
+import LocaleContext from './../../src/component/LocaleContext';
+
+const languageStrategy = defaultUnprefixed({
+  routes: {
+    example: {
+      en: '/example',
+      es: '/ejemplo',
+      fr: '/exemple',
+    },
+  },
+  locales: ['en', 'es', 'fr'],
+  defaultLocale: 'en',
+});
+
+const Base = ({children, history}) => (
+  <I18nRoutingProvider
+    defaultTranslatedRoutes={{es: '/es', en: '/'}}
+    formatIntlRoute={languageStrategy.formatIntlRoute}
+    history={history}
+    localeFromPath={languageStrategy.localeFromLocation}
+  >
+    {children}
+  </I18nRoutingProvider>
+);
+
+test('It passes context to the component through LocaleContext', () => {
+  const Component = ({i18nRouting}) => {
+    i18nRouting.setTranslatedRoutes({es: '/es/ejemplo', en: '/example'});
+
+    return Object.keys(i18nRouting.translatedRoutes).map(key => (
+      <span data-testid={`link-${key}`} key={key}>
+        {i18nRouting.translatedRoutes[key]}
+      </span>
+    ));
+  };
+
+  const {getByTestId} = render(
+    <Base history={createHistory({initialEntries: ['/en']})}>
+      <LocaleContext>{i18nRouting => <Component i18nRouting={i18nRouting} />}</LocaleContext>
+    </Base>,
+  );
+
+  expect(getByTestId('link-es').textContent).toBe('/es/ejemplo');
+  expect(getByTestId('link-en').textContent).toBe('/example');
+});
+
+test('It passes current locale to the component through LocaleContext', () => {
+  const Component = ({locale}) => <span data-testid="link">{locale}</span>;
+
+  const {getByTestId} = render(
+    <Base history={createHistory({initialEntries: ['/en']})}>
+      <LocaleContext>{({locale}) => <Component locale={locale} />}</LocaleContext>
+    </Base>,
+  );
+
+  expect(getByTestId('link').textContent).toBe('en');
+});


### PR DESCRIPTION
In order to avoid exposing unnecessary apis. This PR aims to hide `withI18nRouting` HOC and it provides `LocaleContext` out-of-the-box reducing the boilerplate a little bit. :)

Check the documentation's changes in this PR.